### PR TITLE
Allow completion with new help file format

### DIFF
--- a/lib/cf_completion.rb
+++ b/lib/cf_completion.rb
@@ -34,7 +34,7 @@ module CfCompletion
   end
 
   def self.list_commands(filter)
-    help_output = `cf help | sed -n '/^GETTING STARTED:/,/^ENVIRONMENT VARIABLES/p'`
+    help_output = `cf help`
 
     help_output.
         split("\n").


### PR DESCRIPTION
I'm using `cf` version 6.22 and as a new Cloud Foundry user I was very pleased to find this autocomplete tool however it didn't work for me.  I don't write ruby but I did a bit of debugging and noticed that the sed expression on the help file meant we got no output and therefore no commands.  This patch removes that and allows some commands to work correctly for me (and I'll open an issue for the rest)

I wasn't sure if I should bump the version number, so I didn't.